### PR TITLE
Fixed wrong fs.defaultFS

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -6,6 +6,7 @@ alias la='l -A'
 alias llt='l -lrt'
 alias lla='l -lA'
 alias llat='l -lArt'
+alias h='history'
 
 # hadoop aliases
 unalias fs &> /dev/null

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The `slaves` config file must be modified by hand. Un-/Comment the slaves you wa
 
 `nano /home/vs_pj/hadoop/etc/hadoop/slaves`
 
+You have also to configure the `core-site.xml` manually. Uncomment the master Namenode (asok05 or asok13)
+
+`nano /home/vs_pj/hadoop/etc/hadoop/core-site.xml`
+
 ## Additional stuff
 
 Fix some server pre-configs

--- a/hadoop/core-site.xml
+++ b/hadoop/core-site.xml
@@ -5,7 +5,8 @@
 
 <property>
   <name>fs.defaultFS</name>
-  <value>hdfs://localhost:54310</value>
+  <!-- <value>hdfs://asok05:54310</value> -->
+  <!-- <value>hdfs://asok13:54310</value> -->
   <description>The name of the default file system.  A URI whose
   scheme and authority determine the FileSystem implementation.  The
   uri's scheme determines the config property (fs.SCHEME.impl) naming


### PR DESCRIPTION
I've added a wrong defaultFS address in the core-site.xml. Now I fixed it.
In addition to that i modified the README.
Beside that I added a new alias to the .bash_aliases file, because I'm fequently checked the bash history. 
