### PR TITLE
Add the Hadoop config path to the flink config

### DIFF
--- a/flink/flink-conf.yaml
+++ b/flink/flink-conf.yaml
@@ -101,4 +101,4 @@ state.backend: jobmanager
 # You can also directly specify the paths to hdfs-default.xml and hdfs-site.xml
 # via keys 'fs.hdfs.hdfsdefault' and 'fs.hdfs.hdfssite'.
 #
-# fs.hdfs.hadoopconf: /path/to/hadoop/conf/
+fs.hdfs.hadoopconf: ~/hadoop/etc/hadoop


### PR DESCRIPTION
When we want to work with HDFS Flink needs to know where the configuration of Hadoop are stored. (See https://ci.apache.org/projects/flink/flink-docs-release-0.8/example_connectors.html).
In order to do that I uncommented the entry in Flinks configuration file and added the path to Hadoop configuration.
