### PR TITLE
Update flink-conf.yaml

### DIFF
--- a/flink/flink-conf.yaml
+++ b/flink/flink-conf.yaml
@@ -33,9 +33,9 @@ jobmanager.heap.mb: 256
 
 taskmanager.heap.mb: 512
 
-taskmanager.numberOfTaskSlots: 1
+taskmanager.numberOfTaskSlots: 8
 
-parallelism.default: 1
+parallelism.default: 24
 
 #==============================================================================
 # Web Frontend


### PR DESCRIPTION
Increased the number of Task Slots per Taskmanager to 8 (equal to the number of cores: 4x2) + increased the parallelism to 24 (3 Instances with 8 Slots each)
