### PR TITLE
Fix for Flink choosing the wrong java version, increase available memory

### DIFF
--- a/flink/flink-conf.yaml
+++ b/flink/flink-conf.yaml
@@ -102,4 +102,4 @@ state.backend: jobmanager
 # via keys 'fs.hdfs.hdfsdefault' and 'fs.hdfs.hdfssite'.
 #
 fs.hdfs.hadoopconf: ~/hadoop/etc/hadoop
-env.java.home: opt/jdk.1.8.0_45
+env.java.home: /opt/jdk.1.8.0_45

--- a/flink/flink-conf.yaml
+++ b/flink/flink-conf.yaml
@@ -31,7 +31,7 @@ jobmanager.rpc.port: 6123
 
 jobmanager.heap.mb: 256
 
-taskmanager.heap.mb: 512
+taskmanager.heap.mb: 28000
 
 taskmanager.numberOfTaskSlots: 8
 


### PR DESCRIPTION
Also: Increase available memory for flink
